### PR TITLE
added Guardfile template

### DIFF
--- a/guard-konacha.gemspec
+++ b/guard-konacha.gemspec
@@ -1,6 +1,10 @@
+# -*- encoding: utf-8 -*-
+$:.push File.expand_path('../lib', __FILE__)
+require 'guard/konacha/version'
+
 Gem::Specification.new do |s|
   s.name        = 'guard-konacha'
-  s.version     = '0.1.0'
+  s.version     = Guard::KonachaVersion::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Alex Gibbons']
   s.email       = ['alex.gibbons@gmail.com']

--- a/lib/guard/konacha/templates/Guardfile
+++ b/lib/guard/konacha/templates/Guardfile
@@ -2,5 +2,6 @@
 #  available options:
 #  - :spec_dir
 guard :konacha do
+  watch(%r{^app/assets/javascripts/(.*)\.js(\.coffee)?$}) { |m| "#{m[1]}_spec.js" }
   watch(%r{^spec/javascripts/.+_spec(\.js|\.js\.coffee)})
 end

--- a/lib/guard/konacha/templates/Guardfile
+++ b/lib/guard/konacha/templates/Guardfile
@@ -1,0 +1,6 @@
+### Guard::Konacha
+#  available options:
+#  - :spec_dir
+guard :konacha do
+  watch(%r{^spec/javascripts/.+_spec(\.js|\.js\.coffee)})
+end

--- a/lib/guard/konacha/version.rb
+++ b/lib/guard/konacha/version.rb
@@ -1,0 +1,5 @@
+module Guard
+  module KonachaVersion
+    VERSION = "0.1.0"
+  end
+end


### PR DESCRIPTION
I got a "No such file or directory" error when doing a `be guard init` on a new project.  This PR adds a template for use in that case.  I've also modified your gemspec to use a common convention for specifying a rubygem version via a namespaced constant in a version.rb file.
