### PR TITLE
Correctly notify success/failure when > 9 examples

### DIFF
--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -36,7 +36,7 @@ module Guard
 
         if @options[:notification]
           last_line = result.split("\n").last
-          examples, failures = last_line.scan(/\d/).map { |s| s.to_i }
+          examples, failures = last_line.scan(/\d+/).map { |s| s.to_i }
           image = failures > 0 ? :failed : :success
           ::Guard::Notifier.notify(last_line, :title => 'Konacha Specs', :image => image )
         end


### PR DESCRIPTION
I've fixed the regex used to read how many examples were run/passed/failed. It was only
looking for single digits therefore would incorrectly report a failure when 10 or more examples were passed.
