### PR TITLE
Rewrite Guard-Konacha to increase performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 
 gem 'konacha'
 gem 'childprocess'
+gem 'rb-readline'

--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,7 @@ If your specs live outside of `spec/javascripts` then tell Konacha where to find
       # ...
     end
 
-It you want to use capybara-webkit instead of the default selenium
+If you want to use capybara-webkit instead of the default selenium
 driver:
 
     require 'capybara-webkit'
@@ -39,7 +39,6 @@ driver:
 
 If you are running konacha:serve on a different host or port than the
 default `localhost` and `3500`, the configuration settings `:host` and `:port` will help you there.
-
 
 ## Development
 

--- a/Readme.md
+++ b/Readme.md
@@ -27,7 +27,20 @@ If your specs live outside of `spec/javascripts` then tell Konacha where to find
     guard :konacha, :spec_dir => 'spec/front-end' do
       # ...
     end
-    
+
+It you want to use capybara-webkit instead of the default selenium
+driver:
+
+    require 'capybara-webkit'
+
+    guard :konacha, :driver => :webkit do
+      # ...
+    end
+
+If you are running konacha:serve on a different host or port than the
+default `localhost` and `3500`, the configuration settings `:host` and `:port` will help you there.
+
+
 ## Development
 
 This is a work in progress and could use some help.

--- a/guard-konacha.gemspec
+++ b/guard-konacha.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'guard',   '~> 1.1'
   s.add_dependency 'konacha', '~> 2.0'
+  s.add_dependency 'activesupport', '>= 2.2'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'simplecov'

--- a/guard-konacha.gemspec
+++ b/guard-konacha.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = 'Automatically run konacha tests'
 
   s.add_dependency 'guard',   '~> 1.1'
-  s.add_dependency 'konacha', '~> 2.0'
+  s.add_dependency 'konacha', '>= 2.3'
   s.add_dependency 'activesupport', '>= 2.2'
 
   s.add_development_dependency 'rspec'

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -86,7 +86,7 @@ describe Guard::Konacha::Runner do
       let(:path) { '/model/user_spec' }
       let(:file_path) { 'spec/javascripts/model/user_spec.js.coffee' }
 
-      it 'runs all the tests' do
+      it 'runs specific tests' do
         subject.should_receive(:run_tests).with(konacha_url).and_return passing_result
         ::Guard::UI.should_receive(:info).with("Konacha Running: #{file_path}")
         subject.run [file_path]


### PR DESCRIPTION
Changed the strategy of Guard-Konacha. By updating Konacha to accept a Capybara session and run specific urls, Guard Konacha can use a single Capybara session for all runs. Therefor speeding up the running of tests. The old strategy used running the `konacha:run` rake task, and had to setup a server and capybara session for each run.

In this new strategy, the urls of the tests are visited and listened to using the updated Konacha runner. 

For the new strategy, jfirebaugh/konacha#95 has to be merged first and the new Konacha gem should be released. When that is done, I can update the Gemspec file with the new Konacha version that should be required for this code.
