### PR TITLE
Check spec existence. Fixes #8

### DIFF
--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -64,7 +64,6 @@ module Guard
           test_results[:duration] += individual_result[:duration]
         end
 
-
         result_line = "#{test_results[:examples]} examples, #{test_results[:failures]} failures"
         result_line << ", #{test_results[:pending]} pending" if test_results[:pending] > 0
         text = [
@@ -89,6 +88,10 @@ module Guard
           :pending  => runner.reporter.pending_count,
           :duration => runner.reporter.duration
         }
+      rescue => e
+        puts e.inspect
+        @session = nil
+        #retry
       end
 
       def run_all

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -90,7 +90,7 @@ module Guard
         session.visit url
 
         if session.status_code == 404
-          UI.warning "No Spec found for #{path}"
+          UI.warning "No spec found for: #{path}"
           return EMPTY_RESULT
         end
 

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -195,8 +195,10 @@ describe Guard::Konacha::Runner do
       end
 
       it 'outputs the error to Guard' do
-        ::Guard::UI.should_receive(:error).with '#<ArgumentError: uncaught throw :error>'
-        ::Konacha::Runner.should_receive(:new) { throw :error }
+        ::Guard::UI.should_receive(:error) do |arg|
+          arg.should match(/something_relevant/)
+        end
+        ::Konacha::Runner.should_receive(:new) { throw :something_relevant }
 
         subject.run_tests('dummy url', nil)
       end

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -1,10 +1,13 @@
 require 'spec_helper'
 
 describe Guard::Konacha::Runner do
-  let(:konacha_response) { "Finished in 6 seconds\n5 examples, 0 failures, 0 pending" }
+
   let(:runner) { Guard::Konacha::Runner.new }
 
-  before(:each) do
+  before do
+    # Silence Ui.info output
+    ::Guard::UI.stub :info => true
+
     subject.stub(:konacha_running?) { true }
   end
 
@@ -80,7 +83,7 @@ describe Guard::Konacha::Runner do
       subject { described_class.new :host => host, :port => port }
 
       it 'runs all the tests' do
-        subject.should_receive(:run_tests).with(konacha_url).and_return passing_result
+        subject.should_receive(:run_tests).with(konacha_url, nil).and_return passing_result
         ::Guard::UI.should_receive(:info).with('Konacha Running: All tests')
         subject.run
       end
@@ -91,7 +94,7 @@ describe Guard::Konacha::Runner do
       let(:file_path) { 'spec/javascripts/model/user_spec.js.coffee' }
 
       it 'runs specific tests' do
-        subject.should_receive(:run_tests).with(konacha_url).and_return passing_result
+        subject.should_receive(:run_tests).with(konacha_url, file_path).and_return passing_result
         ::Guard::UI.should_receive(:info).with("Konacha Running: #{file_path}")
         subject.run [file_path]
       end
@@ -123,7 +126,7 @@ describe Guard::Konacha::Runner do
     end
 
     describe 'Capybara session' do
-      let(:fake_session) { double('capybara session') }
+      let(:fake_session) { double('capybara session', :visit => true, :status_code => 200) }
       let(:fake_reporter) do
         double('konacha reporter',
                :example_count => 5,
@@ -141,7 +144,6 @@ describe Guard::Konacha::Runner do
         subject.run
       end
     end
-
   end
 
   describe '.run_all' do
@@ -158,6 +160,45 @@ describe Guard::Konacha::Runner do
       it 'not run all specs' do
         runner.should_not_receive(:run)
         runner.run_all
+      end
+    end
+  end
+
+  describe '.run_tests' do
+    let(:status_code) { 200 }
+    let(:capybara_session) { double('capybara session', :status_code => status_code, :visit => true) }
+    before do
+      subject.stub :session => capybara_session
+    end
+
+    context 'with missing spec' do
+      let(:status_code) { 404 }
+      let(:missing_spec) { 'models/missing_spec' }
+
+      it 'aborts the test with a missing result' do
+        ::Guard::UI.should_receive(:warning).with("No spec found for: #{missing_spec}")
+        ::Konacha::Runner.should_receive(:new).never
+        subject.run_tests('dummy url', missing_spec).should eql described_class::EMPTY_RESULT
+      end
+    end
+
+    context 'with runner raising exception' do
+      before do
+        subject.instance_variable_set(:@session, 'dummy')
+        subject.stub :session => double('capybara session', :status_code => 200, :visit => true)
+        ::Guard::UI.stub :error => true
+      end
+
+      it 'resets the session' do
+        ::Konacha::Runner.should_receive(:new) { throw :error }
+        expect { subject.run_tests('dummy url', nil) }.to change { subject.instance_variable_get(:@session) }.from('dummy').to(nil)
+      end
+
+      it 'outputs the error to Guard' do
+        ::Guard::UI.should_receive(:error).with '#<ArgumentError: uncaught throw :error>'
+        ::Konacha::Runner.should_receive(:new) { throw :error }
+
+        subject.run_tests('dummy url', nil)
       end
     end
   end

--- a/spec/guard/konacha_spec.rb
+++ b/spec/guard/konacha_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe Guard::Konacha do
   subject { Guard::Konacha.new }
 
+  before do
+    # Silence UI.info output
+    ::Guard::UI.stub :info => true
+  end
+
   describe '#initialize' do
     it "instantiates Runner with given options" do
       Guard::Konacha::Runner.should_receive(:new).with(:spec_dir => 'spec/assets')


### PR DESCRIPTION
Visit the suggested konacha url first and check the status code. On 404 output a warning and return an empty result.

Also reset the capybara session if an exception is raised we cannot handle yet.
