### PR TITLE
konacha command as string then split and splat

### DIFF
--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -109,15 +109,15 @@ module Guard
       end
 
       def spawn_konacha_command
-        cmd_parts = []
-        cmd_parts << "bundle exec" if bundler?
+        cmd_parts = ''
+        cmd_parts << "bundle exec " if bundler?
         cmd_parts << "rake konacha:serve"
-        cmd_parts.join(' ')
+        cmd_parts.split
       end
 
       def spawn_konacha
         unless @process
-          @process = ChildProcess.build(spawn_konacha_command)
+          @process = ChildProcess.build(*spawn_konacha_command)
           @process.io.inherit! if ::Guard.respond_to?(:options) && ::Guard.options && ::Guard.options[:verbose]
           @process.start
         end


### PR DESCRIPTION
Hey there,

Thanks for this grunt plugin. It didn't seem to work for me and it seems recent versions of ChildProcess require the command args to be separated.  Please take a look, seems to work well for me. All the tests pass as expected for me.

Thanks again!
