### PR TITLE
Prevent caching results

### DIFF
--- a/guard-konacha.gemspec
+++ b/guard-konacha.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'childprocess', '>= 0.2.5'
 
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'timecop'
   s.add_development_dependency 'simplecov'
 
   s.files        = Dir.glob('{lib}/**/*') + %w[LICENSE Readme.md]

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -87,6 +87,7 @@ module Guard
       }
 
       def run_tests(url, path)
+        session.reset!
         session.visit url
 
         if session.status_code == 404

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -117,7 +117,11 @@ module Guard
 
       def konacha_url(path = nil)
         url_path = path.gsub(/^#{@options[:spec_dir]}\/?/, '').gsub(/\.coffee$/, '').gsub(/\.js$/, '') unless path.nil?
-        "#{konacha_base_url}/#{url_path}?mode=runner"
+        "#{konacha_base_url}/#{url_path}?mode=runner&unique=#{unique_id}"
+      end
+
+      def unique_id
+        "#{Time.now.to_i}#{rand(100)}"
       end
 
       def session

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -134,17 +134,18 @@ describe Guard::Konacha::Runner do
 
         let(:urls) do
           konacha_urls = []
-          runner.should_receive(:run_tests) do |url, path|
+          runner.stub(:run_tests) do |url, path|
             konacha_urls << url
 
             passing_result
-          end.twice
+          end
 
           Timecop.freeze do
             # run the same file twice
 
             runner.run [file_path, file_path]
           end
+
           konacha_urls
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ unless ENV['CI']
 end
 
 require 'rspec'
+require 'timecop'
 require 'guard/konacha'
 
 ENV["GUARD_ENV"] = 'test'


### PR DESCRIPTION
Reset Capybara session before each run to clear cookies (Cucumber::Rails does this aswell)

and add a unique identifier to the url to prevent cached results

Had to add Timecop as development dependency to guarantee uniqueness
