### PR TITLE
Prevent caching of result by making pre-check url and runner url unique

### DIFF
--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -101,7 +101,6 @@ module Guard
         runner = ::Konacha::Runner.new session
         runner.run unique_runner_url(url)
 
-        session.reset!
         return {
           :examples => runner.reporter.example_count,
           :failures => runner.reporter.failure_count,
@@ -110,12 +109,12 @@ module Guard
         }
       rescue => e
         UI.error e.inspect
+      ensure
         clear_session!
       end
 
       def clear_session!
         return unless @session
-        UI.info "Stopping Capybara session"
         @session.reset!
         @session = nil
       end

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -87,10 +87,9 @@ module Guard
         :failures => 0,
         :pending  => 0,
         :duration => 0,
-      }
+      }.freeze
 
       def run_tests(url, path)
-        UI.info "Executing: #{url}"
         session.visit unique_runner_url(url)
 
         if session.status_code == 404
@@ -140,8 +139,7 @@ module Guard
       end
 
       def session
-        UI.info "Starting Konacha-Capybara session using #{@options[:driver]} driver, this can take a few seconds..." if @session.nil?
-        @session ||= Capybara::Session.new @options[:driver]
+        @session || create_session
       end
 
       def spawn_konacha_command

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -109,13 +109,22 @@ module Guard
       rescue => e
         UI.error e.inspect
       ensure
-        clear_session!
+        reset_session!
       end
 
       def clear_session!
         return unless @session
         @session.reset!
         @session = nil
+      end
+
+      def create_session
+        @session = Capybara::Session.new @options[:driver]
+      end
+
+      def reset_session!
+        clear_session!
+        create_session
       end
 
       def run_all

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -90,7 +90,8 @@ module Guard
       }
 
       def run_tests(url, path)
-        session.visit url
+        UI.info "Executing: #{url}"
+        session.visit unique_runner_url(url)
 
         if session.status_code == 404
           UI.warning "No spec found for: #{path}"
@@ -98,7 +99,7 @@ module Guard
         end
 
         runner = ::Konacha::Runner.new session
-        runner.run url
+        runner.run unique_runner_url(url)
 
         session.reset!
         return {
@@ -128,7 +129,11 @@ module Guard
 
       def konacha_url(path = nil)
         url_path = path.gsub(/^#{@options[:spec_dir]}\/?/, '').gsub(/\.coffee$/, '').gsub(/\.js$/, '') unless path.nil?
-        "/#{url_path}?mode=runner&unique=#{unique_id}"
+        "/#{url_path}"
+      end
+
+      def unique_runner_url(path)
+        "#{path}?mode=runner&unique=#{unique_id}"
       end
 
       def unique_id

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -25,6 +25,7 @@ module Guard
 
       def initialize(options={})
         @options = DEFAULT_OPTIONS.merge(options)
+        Capybara.app_host = konacha_base_url
         UI.info "Guard::Konacha Initialized"
       end
 
@@ -117,7 +118,7 @@ module Guard
 
       def konacha_url(path = nil)
         url_path = path.gsub(/^#{@options[:spec_dir]}\/?/, '').gsub(/\.coffee$/, '').gsub(/\.js$/, '') unless path.nil?
-        "#{konacha_base_url}/#{url_path}?mode=runner&unique=#{unique_id}"
+        "/#{url_path}?mode=runner&unique=#{unique_id}"
       end
 
       def unique_id

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -174,7 +174,10 @@ describe Guard::Konacha::Runner do
       subject { described_class.new :driver => :other_driver }
 
       it 'can be configured to another driver' do
-        ::Capybara::Session.should_receive(:new).with(:other_driver).and_return(fake_session)
+        # first run creates inital session, but it is rebuild
+        # when the test is finished. This results in the session
+        # being created twice
+        ::Capybara::Session.should_receive(:new).twice.with(:other_driver).and_return(fake_session)
         ::Konacha::Runner.should_receive(:new).with(fake_session).and_return(fake_runner)
         subject.run
       end
@@ -250,7 +253,8 @@ describe Guard::Konacha::Runner do
 
       it 'resets the session' do
         ::Konacha::Runner.should_receive(:new) { throw :error }
-        expect { subject.run_tests('dummy url', nil) }.to change { subject.instance_variable_get(:@session) }.from(session).to(nil)
+        subject.should_receive :reset_session!
+        subject.run_tests('dummy url', nil)
       end
 
       it 'outputs the error to Guard' do

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -43,6 +43,13 @@ describe Guard::Konacha::Runner do
       let(:runner) { Guard::Konacha::Runner.new :run_all => false }
       it { should eq(Guard::Konacha::Runner::DEFAULT_OPTIONS.merge(:run_all => false)) }
     end
+
+    context 'with specified port and host' do
+      let(:runner) { Guard::Konacha::Runner.new :host => 'other_host', :port => 1234 }
+      it "sets the default Capybara app_host to the correct value" do
+        Capybara.app_host.should eql 'http://other_host:1234'
+      end
+    end
   end
 
   describe '.launch_konacha' do
@@ -66,9 +73,7 @@ describe Guard::Konacha::Runner do
   end
 
   describe '.run' do
-    let(:host) { 'localhost' }
-    let(:port) { 3500 }
-    let(:konacha_url) { %r(^http://#{host}:#{port}#{path}\?mode=runner&unique=\d+$) }
+    let(:konacha_url) { %r(^#{path}\?mode=runner&unique=\d+$) }
 
     let(:failing_result) do
       {
@@ -99,9 +104,6 @@ describe Guard::Konacha::Runner do
 
     context 'without arguments' do
       let(:path) { '/' }
-      let(:port) { 4000 }
-      let(:host) { 'other_host' }
-      subject { described_class.new :host => host, :port => port }
 
       it 'runs all the tests' do
         subject.should_receive(:run_tests) do |url, path|

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -71,6 +71,14 @@ describe Guard::Konacha::Runner do
       subject.kill_konacha
     end
 
+    it 'will stop the server process' do
+      server_process = double('Konacha server process')
+      server_process.should_receive(:stop)
+      subject.instance_variable_set(:@process, server_process)
+
+      subject.kill_konacha
+    end
+
     it 'will reset the current capybara session' do
       subject.should_receive :clear_session!
       subject.kill_konacha

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -204,10 +204,10 @@ describe Guard::Konacha::Runner do
       subject.stub :session => fake_session
     end
 
-    it 'resets the capybara session' do
-      # resetting the session between test runs is default policy. Cucumber::Rails does this aswell.
-      fake_session.should_receive(:reset!).once
+    it 'clears the capybara session' do
       ::Konacha::Runner.should_receive(:new).with(fake_session).and_return fake_runner
+      subject.should_receive :clear_session!
+
       subject.run_tests('dummy url', nil)
     end
 


### PR DESCRIPTION
Somehow after a while tests start to return some sort of cached results.

To battle this sort of caching (because it causes mistrust of tests) I shuffled around the reset code. I also made the `kill_konacha` reset and remove the Capybara session. This helps in that you can now use `reload konacha` if you would run into this cache issue.

I also changed the `session.visit` and `runner.run` urls that they are not the same anymore.
