### PR TITLE
Run all Konacha tests on starting Guard.

### DIFF
--- a/lib/guard/konacha.rb
+++ b/lib/guard/konacha.rb
@@ -15,6 +15,7 @@ module Guard
     def start
       runner.kill_konacha
       runner.launch_konacha("Start")
+      runner.run_all_on_start
     end
 
     def reload

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -160,8 +160,11 @@ module Guard
 
       def wait_for(timeout=10, delay = 0.1)
         Timeout.timeout(timeout) do
-          sleep delay
-          success = yield until success
+          success = false
+          until success do
+            sleep delay
+            success = yield
+          end
         end
       rescue Timeout::Error
         nil

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -15,6 +15,7 @@ module Guard
         :bundler  => true,
         :spec_dir => 'spec/javascripts',
         :run_all  => true,
+        :all_on_start => true,
         :driver   => :selenium,
         :host     => 'localhost',
         :port     => 3500,
@@ -111,6 +112,12 @@ module Guard
         run
       end
 
+      def run_all_on_start
+         return unless @options[:all_on_start] &&  @options[:run_all]
+         wait_for { konacha_running? }
+         run_all
+      end
+
       private
 
       def konacha_url(path = nil)
@@ -149,6 +156,15 @@ module Guard
       def konacha_running?
         Net::HTTP.get_response(URI.parse(konacha_base_url))
       rescue Errno::ECONNREFUSED
+      end
+
+      def wait_for(timeout=10, delay = 0.1)
+        Timeout.timeout(timeout) do
+          sleep delay
+          success = yield until success
+        end
+      rescue Timeout::Error
+        nil
       end
 
       def bundler?


### PR DESCRIPTION
Quick and dirty change to do run of all tests on Guard startup, as guard-rspec does. 

Not the cleanest solution, but with external processes there seldom is. 

NOTE: I ran into an issue where I had to explicitly add:
  require 'capybara/poltergeist'
in my Guardfile for this to work, but that just might be issues with my local setup.
