### PR TITLE
Konacha 3.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 coverage/
+spec/dummy/log/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,11 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
-  - ruby-head
-  - jruby-18mode
+  - 2.0.0
   - jruby-19mode
-  - rbx-18mode
   - rbx-19mode
 
 env:
   - RAILS_VERSION=3.1.0
   - RAILS_VERSION=3.2.0
   - RAILS_VERSION=4.0
-
-matrix:
-  exclude:
-    - rvm: 1.8.7
-      env: RAILS_VERSION=4.0
-    - rvm: 1.9.2
-      env: RAILS_VERSION=4.0
-    - rvm: jruby-18mode
-      env: RAILS_VERSION=4.0
-    - rvm: rbx-18mode
-      env: RAILS_VERSION=4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,23 @@ rvm:
   - 1.9.2
   - 1.9.3
   - ruby-head
-  - ree
   - jruby-18mode
   - jruby-19mode
   - rbx-18mode
   - rbx-19mode
+
+env:
+  - RAILS_VERSION=3.1.0
+  - RAILS_VERSION=3.2.0
+  - RAILS_VERSION=4.0
+
+matrix:
+  exclude:
+    - rvm: 1.8.7
+      env: RAILS_VERSION=4.0
+    - rvm: 1.9.2
+      env: RAILS_VERSION=4.0
+    - rvm: jruby-18mode
+      env: RAILS_VERSION=4.0
+    - rvm: rbx-18mode
+      env: RAILS_VERSION=4.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'http://rubygems.org'
 
 gemspec
+
+gem "rails", "~> #{ENV["RAILS_VERSION"] || '4.0'}"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source 'http://rubygems.org'
 
 gemspec
-
-gem 'konacha'
-gem 'rb-readline'

--- a/Readme.md
+++ b/Readme.md
@@ -1,55 +1,35 @@
-# Guard::Konacha [![Build Status](https://travis-ci.org/alexgb/guard-konacha.png)](https://travis-ci.org/alexgb/guard-konacha)
+# Guard::Konacha [![Build Status](https://travis-ci.org/alexgb/guard-konacha.png?branch=master)](https://travis-ci.org/alexgb/guard-konacha)
 
 Automatically run your [Konacha](https://github.com/jfirebaugh/konacha) tests through [Guard](https://github.com/guard/guard/).
 
 ## Install
 
-Install the gem:
+If you haven't already, start by installing and configuring [Konacha](https://github.com/jfirebaugh/konacha). Then add the `guard-konacha` gem to your Gemfile:
 
-    $ gem install guard-konacha
-
-Or add to your Gemfile:
-
+    # Gemfile
     gem 'guard-konacha'
 
-## Usage
+And install
 
-Add guard definitions to your `Guardfile`
+    $ bundle install
 
-    guard :konacha do
-      watch(%r{^app/assets/javascripts/(.*)\.js(\.coffee)?$}) { |m| "#{m[1]}_spec.js" }
-      watch(%r{^spec/javascripts/.+_spec(\.js|\.js\.coffee)$})
-    end
+## Setup
 
-## Configuration
+Add the default configurations to your Guardfile.
 
-If your specs live outside of `spec/javascripts` then tell Konacha where to find them.
+    $ bundle exec guard init konacha
 
-    guard :konacha, :spec_dir => 'spec/front-end' do
-      # ...
-    end
+## Run
 
-If you want to use [capybara-webkit](https://github.com/thoughtbot/capybara-webkit) instead of the default selenium
-driver:
+And that's it. Your Konacha powered JavaScript tests will now run whenever your JavaScript assets or spec files change.
 
-    require 'capybara-webkit'
-    guard :konacha, :driver => :webkit do
-      # ...
-    end
+    $ bundle exec guard
 
-Or use [Poltergeist](https://github.com/jonleighton/poltergeist):
+## Additionally
 
-    require 'capybara/poltergeist'
-    guard :konacha, :driver => :poltergeist do
-      # ...
-    end
+I recommend using the [capybara-webkit](https://github.com/thoughtbot/capybara-webkit) or [poltergeist](https://github.com/jonleighton/poltergeist) drivers rather than the default selenium based driver. See [Konacha instructions](https://github.com/jfirebaugh/konacha#configuration). 
 
-If you are running konacha:serve on a different host or port than the
-default `localhost` and `3500`, the configuration settings `:host` and `:port` will help you there.
-
-## Development
-
-This is a work in progress and could use some help.
+To get system notifications see [Guard instructions](https://github.com/guard/guard/wiki/System-notifications).
 
 ## Contributors
 

--- a/guard-konacha.gemspec
+++ b/guard-konacha.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'guard',   '~> 1.1'
   s.add_dependency 'konacha', '>= 3.0'
 
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '>= 2.13'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'poltergeist'

--- a/guard-konacha.gemspec
+++ b/guard-konacha.gemspec
@@ -9,17 +9,16 @@ Gem::Specification.new do |s|
   s.authors     = ['Alex Gibbons']
   s.email       = ['alex.gibbons@gmail.com']
   s.homepage    = 'https://github.com/alexgb/guard-konacha'
-  s.summary     = 'Guard gem for Konacha'
+  s.summary     = 'Guard plugin for Konacha'
   s.description = 'Automatically run konacha tests'
 
   s.add_dependency 'guard',   '~> 1.1'
-  s.add_dependency 'konacha', '>= 2.3'
-  s.add_dependency 'activesupport', '>= 2.2'
-  s.add_dependency 'childprocess', '>= 0.2.5'
+  s.add_dependency 'konacha', '>= 3.0'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'poltergeist'
 
   s.files        = Dir.glob('{lib}/**/*') + %w[LICENSE Readme.md]
   s.require_path = 'lib'

--- a/lib/guard/konacha.rb
+++ b/lib/guard/konacha.rb
@@ -5,6 +5,9 @@ module Guard
   class Konacha < Guard
 
     autoload :Runner, 'guard/konacha/runner'
+    autoload :Formatter, 'guard/konacha/formatter'
+    autoload :Server, 'guard/konacha/server'
+
     attr_accessor :runner
 
     def initialize(watchers=[], options={})
@@ -13,18 +16,11 @@ module Guard
     end
 
     def start
-      runner.kill_konacha
-      runner.launch_konacha("Start")
-      runner.run_all_on_start
-    end
-
-    def reload
-      runner.kill_konacha
-      runner.launch_konacha("Reload")
+      runner.start
     end
 
     def run_all
-      runner.run_all
+      runner.run
     end
 
     def run_on_changes(paths)
@@ -32,10 +28,6 @@ module Guard
     end
     # for guard 1.0.x and earlier
     alias :run_on_change :run_on_changes
-
-    def stop
-      runner.kill_konacha
-    end
 
   end
 end

--- a/lib/guard/konacha.rb
+++ b/lib/guard/konacha.rb
@@ -1,5 +1,7 @@
 require 'guard'
 require 'guard/guard'
+require 'rails'
+require 'konacha'
 
 module Guard
   class Konacha < Guard

--- a/lib/guard/konacha/formatter.rb
+++ b/lib/guard/konacha/formatter.rb
@@ -1,0 +1,58 @@
+module Guard
+  class Konacha
+    class Formatter < ::Konacha::Formatter
+
+      def initialize
+        super($stdout)
+      end
+
+      def reset
+        io.puts ""
+        @examples = []
+      end
+
+      def dump_summary(duration, example_count, failure_count, pending_count); end
+      def dump_failures; end
+      def dump_pending; end
+
+      def success?
+        failed_examples.empty?
+      end
+
+      def failed_examples
+        @examples.select(&:failed?).select(&:exception)
+      end
+
+      def pending_examples
+        @examples.select(&:pending?)
+      end
+
+      def summary_line
+        "#{examples.size} examples, #{failed_examples.size} failed, #{pending_examples.size} pending"
+      end
+
+      def write_summary
+        io.puts ""
+        write_failed_examples
+        write_pending_examples
+        io.puts ""
+        io.puts summary_line
+      end
+
+      def write_failed_examples
+        examples = failed_examples
+        unless examples.empty?
+          io.puts examples.map { |e| failure_message(e) }.join("\n\n")
+        end
+      end
+
+      def write_pending_examples
+        examples = pending_examples
+        unless examples.empty?
+          io.puts examples.map { |e| pending_message(e) }.join("\n\n")
+        end
+      end
+
+    end
+  end
+end

--- a/lib/guard/konacha/formatter.rb
+++ b/lib/guard/konacha/formatter.rb
@@ -19,18 +19,6 @@ module Guard
         failed_examples.empty?
       end
 
-      def failed_examples
-        @examples.select(&:failed?).select(&:exception)
-      end
-
-      def pending_examples
-        @examples.select(&:pending?)
-      end
-
-      def summary_line
-        "#{examples.size} examples, #{failed_examples.size} failed, #{pending_examples.size} pending"
-      end
-
       def write_summary
         io.puts ""
         io.puts [
@@ -39,6 +27,22 @@ module Guard
         ].reject(&:empty?).join("\n\n")
         io.puts ""
         io.puts summary_line
+      end
+
+      def summary_line
+        "#{examples.size} examples, #{failed_examples.size} failed, #{pending_examples.size} pending"
+      end
+
+
+      private
+
+
+      def failed_examples
+        @examples.select(&:failed?).select(&:exception)
+      end
+
+      def pending_examples
+        @examples.select(&:pending?)
       end
 
       def failed_examples_message

--- a/lib/guard/konacha/formatter.rb
+++ b/lib/guard/konacha/formatter.rb
@@ -33,24 +33,28 @@ module Guard
 
       def write_summary
         io.puts ""
-        write_failed_examples
-        write_pending_examples
+        io.puts [
+          failed_examples_message,
+          pending_examples_message
+        ].reject(&:empty?).join("\n\n")
         io.puts ""
         io.puts summary_line
       end
 
-      def write_failed_examples
-        examples = failed_examples
-        unless examples.empty?
-          io.puts examples.map { |e| failure_message(e) }.join("\n\n")
-        end
+      def failed_examples_message
+        failed_examples.map { |e| failure_message(e) }.join("\n\n")
       end
 
-      def write_pending_examples
-        examples = pending_examples
-        unless examples.empty?
-          io.puts examples.map { |e| pending_message(e) }.join("\n\n")
-        end
+      def failure_message(example)
+        "  \xE2\x9C\x96 ".red + "#{example.metadata['path']}\n" + super
+      end
+
+      def pending_examples_message
+        pending_examples.map { |e| pending_message(e) }.join("\n\n")
+      end
+
+      def pending_message(example)
+        "  \xE2\x97\x8B ".yellow + "#{example.metadata['path']}\n" + super
       end
 
     end

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -8,12 +8,13 @@ module Guard
         :rails_environment_file => './config/environment'
       }
 
-      attr_reader :options
+      attr_reader :options, :formatter
 
       def initialize(options={})
         @options = DEFAULT_OPTIONS.merge(options)
 
-        # Must require user's rails environment prior to requiring Konacha
+        # Require project's rails environment file to load Konacha 
+        # configuration
         require_rails_environment
         raise "Konacha not loaded" unless defined? ::Konacha
 
@@ -34,13 +35,13 @@ module Guard
       end
 
       def run(paths = [''])
-        @formatter.reset
+        formatter.reset
 
         paths.each do |path|
           runner.run konacha_path(path)
         end
 
-        @formatter.write_summary
+        formatter.write_summary
         notify
       rescue => e
         UI.error(e)

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -1,182 +1,71 @@
-require 'net/http'
-require 'childprocess'
-require 'capybara'
-require 'active_support/core_ext/module/delegation'
-require 'active_support/core_ext/object/blank'
-require 'konacha/reporter'
-require 'konacha/formatter'
-require 'konacha/runner'
-
 module Guard
   class Konacha
     class Runner
 
       DEFAULT_OPTIONS = {
-        :bundler  => true,
-        :spec_dir => 'spec/javascripts',
-        :run_all  => true,
-        :all_on_start => true,
-        :driver   => :selenium,
-        :host     => 'localhost',
-        :port     => 3500,
+        :run_all_on_start => :true,
         :notification => true,
-        :spawn_wait => 20
+        :rails_environment_file => './config/environment'
       }
 
-      attr_reader :options
+      attr_reader :options, :session
 
       def initialize(options={})
         @options = DEFAULT_OPTIONS.merge(options)
+
+        # Require rails config/environment
+        require @options[:rails_environment_file]
+
+        # Custom formatter to handle multiple runs
+        @formatter = Formatter.new
+        ::Konacha.config.formatters = [@formatter]
+
+        # Reuse session to increase performance
+        @session = Capybara::Session.new(::Konacha.driver, Server.new)
+
+        ::Konacha.mode = :runner
+
         UI.info "Guard::Konacha Initialized"
       end
 
-      def launch_konacha(action)
-        UI.info "#{action}ing Konacha", :reset => true
-        spawn_konacha
+      def runner
+        ::Konacha::Runner.new(session)
       end
 
-      def kill_konacha
-        clear_session!
-        if @process
-          @process.stop(5)
-          UI.info "Konacha Stopped", :reset => true
-        end
+      def start
+        run if options[:run_all_on_start]
       end
 
-      def run(paths=[])
-        return UI.info("Konacha server not running") unless konacha_running?
+      def run(paths = [''])
+        @formatter.reset
 
-        UI.info "Konacha Running: #{paths.empty? ? 'All tests' : paths.join(' ')}"
-
-        urls = paths.map { |p| konacha_url(p) }
-        urls = [konacha_url] if paths.empty?
-
-        test_results = {
-          :examples => 0,
-          :failures => 0,
-          :pending  => 0,
-          :duration => 0
-        }
-
-        urls.each_with_index do |url, index|
-          individual_result = run_tests(url, paths[index])
-
-          test_results[:examples] += individual_result[:examples]
-          test_results[:failures] += individual_result[:failures]
-          test_results[:pending]  += individual_result[:pending]
-          test_results[:duration] += individual_result[:duration]
+        paths.each do |path|
+          runner.run konacha_path(path)
         end
 
-        result_line = "#{test_results[:examples]} examples, #{test_results[:failures]} failures"
-        result_line << ", #{test_results[:pending]} pending" if test_results[:pending] > 0
-        text = [
-          result_line,
-          "in #{"%.2f" % test_results[:duration]} seconds"
-        ].join "\n"
-
-        UI.info text if urls.length > 1
-
-        if @options[:notification]
-          image = test_results[:failures] > 0 ? :failed : :success
-          ::Guard::Notifier.notify(text, :title => 'Konacha Specs', :image => image )
-        end
-      end
-
-      EMPTY_RESULT = {
-        :examples => 0,
-        :failures => 0,
-        :pending  => 0,
-        :duration => 0,
-      }
-
-      def run_tests(url, path)
-        session.reset!
-        unless valid_spec? url
-          UI.warning "No spec found for: #{path}"
-          return EMPTY_RESULT
-        end
-
-        runner = ::Konacha::Runner.new session
-        runner.run url
-        return {
-          :examples => runner.reporter.example_count,
-          :failures => runner.reporter.failure_count,
-          :pending  => runner.reporter.pending_count,
-          :duration => runner.reporter.duration
-        }
+        @formatter.write_summary
+        notify
       rescue => e
-        UI.error e.inspect
-        @session = nil
+        UI.error(e)
       end
 
-      def run_all
-        run if @options[:run_all]
+      def notify
+        if options[:notification]
+          image = @formatter.success? ? :success : :failed
+          ::Guard::Notifier.notify(@formatter.summary_line, :title => "Konacha Specs", :image => image)
+        end
       end
 
-      def run_all_on_start
-         run_all if @options[:all_on_start]
-      end
 
       private
 
-      def konacha_url(path = nil)
-        url_path = path.gsub(/^#{@options[:spec_dir]}\/?/, '').gsub(/\.coffee$/, '').gsub(/\.js$/, '') unless path.nil?
-        "#{konacha_base_url}/#{url_path}?mode=runner&unique=#{unique_id}"
+
+      def konacha_path(path)
+        '/' + path.gsub(/^#{::Konacha.config[:spec_dir]}\/?/, '').gsub(/\.coffee$/, '').gsub(/\.js$/, '')
       end
 
       def unique_id
         "#{Time.now.to_i}#{rand(100)}"
-      end
-
-      def session
-        UI.info "Starting Konacha-Capybara session using #{@options[:driver]} driver, this can take a few seconds..." if @session.nil?
-        @session ||= Capybara::Session.new @options[:driver]
-      end
-
-      def clear_session!
-        return unless @session
-        @session.reset!
-        @session = nil
-      end
-
-      def spawn_konacha_command
-        cmd_parts = ''
-        cmd_parts << "bundle exec " if bundler?
-        cmd_parts << "rake konacha:serve"
-        cmd_parts.split
-      end
-
-      def spawn_konacha
-        unless @process
-          @process = ChildProcess.build(*spawn_konacha_command)
-          @process.io.inherit! if ::Guard.respond_to?(:options) && ::Guard.options && ::Guard.options[:verbose]
-          @process.start
-
-           Timeout::timeout(@options[:spawn_wait]) do
-            until konacha_running?
-              sleep(0.2)
-            end
-          end
-        end
-      end
-
-      def konacha_base_url
-        "http://#{@options[:host]}:#{@options[:port]}"
-      end
-
-      def konacha_running?
-        Net::HTTP.get_response(URI.parse(konacha_base_url))
-      rescue Errno::ECONNREFUSED
-      end
-
-      def bundler?
-        @bundler ||= options[:bundler] != false && File.exist?("#{Dir.pwd}/Gemfile")
-      end
-
-      def valid_spec? url
-        session.visit url
-        konacha_spec = session.evaluate_script('typeof window.top.Konacha')
-        konacha_spec == 'object'
       end
 
     end

--- a/lib/guard/konacha/server.rb
+++ b/lib/guard/konacha/server.rb
@@ -1,0 +1,32 @@
+module Guard
+  class Konacha
+    class Server < Rack::Builder
+
+      def self.new
+        super do
+          use CacheBuster
+          run ::Konacha.application
+        end
+      end
+
+      class CacheBuster
+
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          status, headers, body = @app.call(env)
+
+          headers.delete('Last-Modified')
+          headers.delete('ETag')
+          headers.delete('Cache-Control')
+
+          [status, headers, body]
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/guard/konacha/templates/Guardfile
+++ b/lib/guard/konacha/templates/Guardfile
@@ -1,7 +1,9 @@
 ### Guard::Konacha
 #  available options:
-#  - :spec_dir, defaults to 'spec/javascripts'
-#  - :driver, defaults to :selenium
+#  - :run_all_on_start, defaults to :true
+#  - :notification, defaults to :true
+#  - :rails_environment_file, location of rails environment file,
+#    should be able to find it automatically
 guard :konacha do
   watch(%r{^app/assets/javascripts/(.*)\.js(\.coffee)?$}) { |m| "#{m[1]}_spec.js" }
   watch(%r{^spec/javascripts/.+_spec(\.js|\.js\.coffee)$})

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -1,0 +1,4 @@
+# This file is used by Rack-based servers to start the application.
+
+require ::File.expand_path('../config/environment',  __FILE__)
+run Dummy::Application

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,0 +1,11 @@
+require File.expand_path('../boot', __FILE__)
+
+require 'rails/all'
+
+Bundler.require(:default, Rails.env)
+
+module Dummy
+  class Application < Rails::Application
+    config.assets.enabled = true
+  end
+end

--- a/spec/dummy/config/boot.rb
+++ b/spec/dummy/config/boot.rb
@@ -1,0 +1,6 @@
+require 'rubygems'
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../Gemfile', __FILE__)
+
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])

--- a/spec/dummy/config/environment.rb
+++ b/spec/dummy/config/environment.rb
@@ -1,0 +1,5 @@
+# Load the rails application
+require File.expand_path('../application', __FILE__)
+
+# Initialize the rails application
+Dummy::Application.initialize!

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -1,0 +1,27 @@
+Dummy::Application.configure do
+  # Settings specified here will take precedence over those in config/application.rb
+
+  # In the development environment your application's code is reloaded on
+  # every request. This slows down response time but is perfect for development
+  # since you don't have to restart the web server when you make code changes.
+  config.cache_classes = false
+
+  # Do not eager load in development.
+  config.eager_load = false
+
+  # Show full error reports and disable caching
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+
+  # Print deprecation notices to the Rails logger
+  config.active_support.deprecation = :log
+
+  # Only use best-standards-support built into browsers
+  config.action_dispatch.best_standards_support = :builtin
+
+  # Do not compress assets
+  config.assets.compress = false
+
+  # Expands the lines which load the assets
+  config.assets.debug = true
+end

--- a/spec/dummy/config/initializers/konacha.rb
+++ b/spec/dummy/config/initializers/konacha.rb
@@ -1,0 +1,5 @@
+require 'capybara/poltergeist'
+
+Konacha.configure do |config|
+  config.driver = :poltergeist
+end if defined?(Konacha)

--- a/spec/dummy/config/initializers/secret_token.rb
+++ b/spec/dummy/config/initializers/secret_token.rb
@@ -1,0 +1,12 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+
+# Make sure your secret_key_base is kept private
+# if you're sharing your code publicly.
+Dummy::Application.config.secret_key_base = '5a0339f1e762dc48bf321540ed76855703a60dd523c42ec8c8af9044326707aa8f76f46efab628b91469de554e259e577bfb8ebb35828ca62bb55bcdcd6e1a41'

--- a/spec/guard/konacha/formatter_spec.rb
+++ b/spec/guard/konacha/formatter_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe Guard::Konacha::Formatter do
+
+  let(:formatter) { Guard::Konacha::Formatter.new }
+
+  it 'should respond not implemented base class methods' do
+    formatter.should respond_to(:dump_summary).with(4).arguments
+    formatter.should respond_to(:dump_failures)
+    formatter.should respond_to(:dump_pending)
+  end
+
+  describe('#reset') do
+    it 'should respond to reset' do
+      formatter.should respond_to(:reset)
+    end
+  end
+
+  describe('#write_summary') do
+    MockException = Struct.new(:message, :backtrace)
+    Example = Struct.new(:full_description, :exception, :metadata, :failed?, :pending?)
+
+    def create_example(options)
+      example = Example.new(options[:message], options[:exception], {}, options[:failed?], options[:pending?])
+
+      def example.failed?; self[:failed?]; end
+      def example.pending?; self[:pending?]; end
+      example
+    end
+
+    let(:failure) do
+      create_example({
+        :message => "Bad",
+        :exception => MockException.new("Exception", nil),
+        :failed? => true,
+        :pending? => false
+      })
+    end
+    let(:success) do
+      create_example({
+        :message => "Good",
+        :failed? => false,
+        :pending? => false
+      })
+    end
+    let(:pending) do
+      create_example({
+        :message => "OK",
+        :failed? => false,
+        :pending? => true
+      })
+    end
+
+    let(:io) { double("IO") }
+
+    before do
+      formatter.stub(:io) { io }
+    end
+
+    it 'should examples to output' do
+      io.should_receive(:write).with("F".red).ordered
+      io.should_receive(:write).with(".".green).ordered
+      io.should_receive(:write).with("P".yellow).ordered
+
+      io.should_receive(:puts).with(any_args).at_least(:once)
+
+      formatter.example_failed(failure)
+      formatter.example_passed(success)
+      formatter.example_pending(pending)
+
+      formatter.write_summary
+    end
+  end
+
+end

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -2,425 +2,49 @@ require 'spec_helper'
 
 describe Guard::Konacha::Runner do
 
-  let(:runner) { Guard::Konacha::Runner.new }
-
-  let(:status_code) { 200 }
-  let(:fake_session) do
-    double('capybara session',
-           :reset! => true,
-           :visit => true,
-           :evaluate_script => true)
-  end
-  let(:fake_reporter) do
-    double('konacha reporter',
-           :example_count => 5,
-           :failure_count => 2,
-           :pending_count => 1,
-           :duration => 0.3
-          )
-  end
-  let(:fake_runner) do
-    double('konacha runner',
-           :run => true,
-           :reporter => fake_reporter)
-  end
+  let(:rails_env_file) { File.expand_path('../../../dummy/config/environment', __FILE__) }
+  let(:runner_options) { { :rails_environment_file => rails_env_file } }
+  let(:runner) { Guard::Konacha::Runner.new runner_options }
 
   before do
     # Silence Ui.info output
     ::Guard::UI.stub :info => true
-
-    subject.stub(:konacha_running?) { true }
   end
 
   describe '#initialize' do
-    subject { runner.options }
-
-    context 'with default options' do
-      it { should eq(Guard::Konacha::Runner::DEFAULT_OPTIONS) }
+    it 'should have default options and allow overrides' do
+      runner.options.should eq(Guard::Konacha::Runner::DEFAULT_OPTIONS.merge(runner_options))
     end
 
-    context 'with run_all => false' do
-      let(:runner) { Guard::Konacha::Runner.new :run_all => false }
-      it { should eq(Guard::Konacha::Runner::DEFAULT_OPTIONS.merge(:run_all => false)) }
+    it 'should set Konacha mode to runner' do
+      ::Konacha.mode.should eq(:runner)
     end
   end
 
-  describe '.launch_konacha' do
-    subject { Guard::Konacha::Runner.new }
+  describe '#start' do
+    let(:runner_options) { super().merge(:run_all_on_start => true) }
+    it 'should run all if :run_all_on_start option set to true' do
+      runner.should_receive(:run).with(no_args)
+      runner.start
+    end
+  end
+
+  describe '#run' do
+    let(:konacha_runner) { double("konacha runner") }
+    let(:konacha_formatter) { double("konacha formatter") }
 
     before do
-      subject.should_receive(:bundler?).any_number_of_times.and_return(false)
+      runner.stub(:runner) { konacha_runner }
+      runner.stub(:formatter) { konacha_formatter }
     end
 
-    it "launches spin server with cli options" do
-      subject.should_receive(:spawn_konacha).once
-      subject.launch_konacha('Start')
-    end
-  end
-
-  describe '.kill_konacha' do
-
-    it 'will not call Process#kill without spin_id' do
-      Process.should_not_receive(:kill)
-      subject.kill_konacha
-    end
-
-    it 'will stop the server process' do
-      server_process = double('Konacha server process')
-      server_process.should_receive(:stop)
-      subject.instance_variable_set(:@process, server_process)
-
-      subject.kill_konacha
-    end
-
-    describe 'clearing capybara session' do
-      let(:session) { double('capybara session', :reset! => true) }
-
-      before do
-        subject.instance_variable_set(:@session, session)
-      end
-
-      it 'will clear the current capybara session' do
-        expect {
-          subject.kill_konacha
-        }.to change { subject.instance_variable_get(:@session) }.to nil
-      end
-
-      it 'will reset session before clearing' do
-        session.should_receive :reset!
-        subject.kill_konacha
-      end
+    it 'should run each path through runner and format results' do
+      konacha_formatter.should_receive(:reset)
+      konacha_runner.should_receive(:run).with('/1')
+      konacha_runner.should_receive(:run).with('/foo/bar')
+      konacha_formatter.should_receive(:write_summary)
+      runner.run(['spec/javascripts/1.js', 'spec/javascripts/foo/bar.js'])
     end
   end
 
-  describe '.run' do
-    let(:host) { 'localhost' }
-    let(:port) { 3500 }
-    let(:konacha_url) { %r(^http://#{host}:#{port}#{path}\?mode=runner&unique=\d+$) }
-
-    let(:failing_result) do
-      {
-        :examples => 3,
-        :failures => 3,
-        :pending  => 0,
-        :duration => 2.5056
-      }
-    end
-
-    let(:passing_result) do
-      {
-        :examples => 2,
-        :failures => 0,
-        :pending  => 0,
-        :duration => 0.3056
-      }
-    end
-
-    let(:pending_result) do
-      {
-        :examples => 2,
-        :failures => 0,
-        :pending  => 2,
-        :duration => 2.8
-      }
-    end
-
-    context 'without arguments' do
-      let(:path) { '/' }
-      let(:port) { 4000 }
-      let(:host) { 'other_host' }
-      subject { described_class.new :host => host, :port => port }
-
-      it 'runs all the tests' do
-        subject.should_receive(:run_tests) do |url, path|
-          url.should match konacha_url
-          path.should be_nil
-
-          passing_result
-        end
-        ::Guard::UI.should_receive(:info).with('Konacha Running: All tests')
-        subject.run
-      end
-    end
-
-    context 'with arguments' do
-      let(:path) { '/model/user_spec' }
-      let(:file_path) { 'spec/javascripts/model/user_spec.js.coffee' }
-
-      it 'runs specific tests' do
-        subject.should_receive(:run_tests) do |url, path|
-          url.should match konacha_url
-          path.should eql file_path
-
-          passing_result
-        end
-        ::Guard::UI.should_receive(:info).with("Konacha Running: #{file_path}")
-        subject.run [file_path]
-      end
-
-      describe 'running the same test twice' do
-
-        let(:urls) do
-          konacha_urls = []
-          runner.stub(:run_tests) do |url, path|
-            konacha_urls << url
-
-            passing_result
-          end
-
-          Timecop.freeze do
-            # run the same file twice
-
-            runner.run [file_path, file_path]
-          end
-
-          konacha_urls
-        end
-
-        subject { urls.uniq }
-
-        it 'guarantees a unique url' do
-          should_not have(1).url
-        end
-      end
-    end
-
-    it 'aggregates multiple test results' do
-      files = [
-        'spec/javascripts/model/user_spec.js.coffee',
-        'spec/javascripts/model/profile_spec.js.coffee'
-      ]
-      subject.should_receive(:run_tests).twice.and_return(passing_result, failing_result)
-      ::Guard::UI.should_receive(:info).with("Konacha Running: #{files.join(' ')}")
-      ::Guard::UI.should_receive(:info).with("5 examples, 3 failures\nin 2.81 seconds")
-      subject.run files
-    end
-
-    describe 'notifications' do
-      subject { described_class.new :notifications => true }
-
-      it 'sends text information to the Guard::Notifier' do
-        subject.should_receive(:run_tests).exactly(3).times.and_return(passing_result, pending_result, failing_result)
-        ::Guard::Notifier.should_receive(:notify).with(
-          "7 examples, 3 failures, 2 pending\nin 5.61 seconds",
-          :title => 'Konacha Specs',
-          :image => :failed
-        )
-        subject.run ['a', 'b', 'c']
-      end
-    end
-
-    describe 'Capybara session' do
-      subject { described_class.new :driver => :other_driver }
-      before do
-        subject.stub :valid_spec? => true
-      end
-
-      it 'can be configured to another driver' do
-        ::Capybara::Session.should_receive(:new).with(:other_driver).and_return(fake_session)
-        ::Konacha::Runner.should_receive(:new).with(fake_session).and_return(fake_runner)
-        subject.run
-        end
-      end
-    end
-
-    describe '.run_all' do
-      context 'with rspec' do
-      it "calls Runner.run with 'spec'" do
-        subject.should_receive(:run)
-        subject.run_all
-      end
-    end
-
-    context 'with :run_all set to false' do
-      let(:runner) { Guard::Konacha::Runner.new :run_all => false }
-
-      it 'not run all specs' do
-        runner.should_not_receive(:run)
-        runner.run_all
-      end
-    end
-  end
-
-  describe '.run_all_on_start' do
-    it "calls Runner.run with 'spec'" do
-      subject.should_receive(:run_all)
-      subject.run_all_on_start
-    end
-
-    context 'with :all_on_start set to false' do
-      let(:runner) { Guard::Konacha::Runner.new :all_on_start => false }
-
-      it 'not run all specs' do
-        runner.should_not_receive(:run_all)
-        runner.run_all_on_start
-      end
-    end
-  end
-
-  describe '.run_tests' do
-    before do
-      subject.stub :session => fake_session, :valid_spec? => true
-    end
-
-    it 'resets the capybara session' do
-      # resetting the session between test runs is default policy. Cucumber::Rails does this aswell.
-      fake_session.should_receive(:reset!).once
-      ::Konacha::Runner.should_receive(:new).with(fake_session).and_return fake_runner
-      subject.run_tests('dummy url', nil)
-    end
-
-    context 'with missing spec' do
-      before do
-        subject.stub(:valid_spec? => false)
-        ::Guard::UI.stub :warning => true
-      end
-      let(:missing_spec) { 'models/missing_spec' }
-
-      it 'aborts the test with a missing result' do
-        ::Konacha::Runner.should_receive(:new).never
-        subject.run_tests('dummy url', missing_spec).should eql described_class::EMPTY_RESULT
-      end
-
-      it 'outputs that the spec is missing' do
-        ::Guard::UI.should_receive(:warning).with("No spec found for: #{missing_spec}")
-        subject.run_tests('dummy url', missing_spec)
-      end
-    end
-
-    context 'with runner raising exception' do
-      before do
-        subject.instance_variable_set(:@session, 'dummy')
-        subject.stub :session => fake_session
-        ::Guard::UI.stub :error => true
-      end
-
-      it 'resets the session' do
-        ::Konacha::Runner.should_receive(:new) { throw :error }
-        expect { subject.run_tests('dummy url', nil) }.to change { subject.instance_variable_get(:@session) }.from('dummy').to(nil)
-      end
-
-      it 'outputs the error to Guard' do
-        ::Guard::UI.should_receive(:error) do |arg|
-          arg.should match(/something_relevant/)
-        end
-        ::Konacha::Runner.should_receive(:new) { throw :something_relevant }
-
-        subject.run_tests('dummy url', nil)
-      end
-    end
-  end
-
-  describe '.valid_spec?' do
-    let(:runner) { described_class.new :driver => :other_driver }
-    before do
-      ::Capybara::Session.should_receive(:new).with(:other_driver).and_return(fake_session)
-    end
-
-    let(:url) { 'http://example.com/' }
-    let(:valid_spec) { runner.send(:valid_spec?, url) }
-
-    it 'visits the url in advance' do
-      fake_session.should_receive(:visit).with(url)
-      valid_spec
-    end
-
-    it 'will verify page health using javascript' do
-      fake_session.should_receive(:evaluate_script).with('typeof window.top.Konacha')
-      valid_spec
-    end
-
-    context 'with spec loaded correctly' do
-      before do
-        fake_session.should_receive(:evaluate_script).and_return 'object'
-      end
-      it { valid_spec.should be_true }
-    end
-
-    context 'with spec loaded incorrectly' do
-      before do
-        fake_session.should_receive(:evaluate_script).and_return 'undefined'
-      end
-      it { valid_spec.should be_false }
-    end
-
-  end
-
-  describe '.bundler?' do
-    before do
-      Dir.stub(:pwd).and_return("")
-    end
-
-    context 'with no bundler option' do
-      subject { Guard::Konacha::Runner.new }
-
-      context 'with Gemfile' do
-        before do
-          File.should_receive(:exist?).with('/Gemfile').and_return(true)
-        end
-
-        it 'return true' do
-          subject.send(:bundler?).should be_true
-        end
-      end
-
-      context 'with no Gemfile' do
-        before do
-          File.should_receive(:exist?).with('/Gemfile').and_return(false)
-        end
-
-        it 'return false' do
-          subject.send(:bundler?).should be_false
-        end
-      end
-    end
-
-    context 'with :bundler => false' do
-      subject { Guard::Konacha::Runner.new :bundler => false }
-
-      context 'with Gemfile' do
-        before do
-          File.should_not_receive(:exist?)
-        end
-
-        it 'return false' do
-          subject.send(:bundler?).should be_false
-        end
-      end
-
-      context 'with no Gemfile' do
-        before do
-          File.should_not_receive(:exist?)
-        end
-
-        it 'return false' do
-          subject.send(:bundler?).should be_false
-        end
-      end
-    end
-
-    context 'with :bundler => true' do
-      subject { Guard::Konacha::Runner.new :bundler => true }
-
-      context 'with Gemfile' do
-        before do
-          File.should_receive(:exist?).with('/Gemfile').and_return(true)
-        end
-
-        it 'return true' do
-          subject.send(:bundler?).should be_true
-        end
-      end
-
-      context 'with no Gemfile' do
-        before do
-          File.should_receive(:exist?).with('/Gemfile').and_return(false)
-        end
-
-        it 'return false' do
-          subject.send(:bundler?).should be_false
-        end
-      end
-    end
-  end
 end

--- a/spec/guard/konacha/server_spec.rb
+++ b/spec/guard/konacha/server_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe Guard::Konacha::Server do
+
+  describe ".new" do
+    it "should use CacheBuster" do
+      Guard::Konacha::Server.any_instance.should_receive(:use).with(Guard::Konacha::Server::CacheBuster)
+      Guard::Konacha::Server.any_instance.should_receive(:run).with(::Konacha.application)
+      Guard::Konacha::Server.new
+    end
+  end
+
+  describe Guard::Konacha::Server::CacheBuster do
+    include Rack::Test::Methods
+
+    let(:app) do
+      Guard::Konacha::Server::CacheBuster.new(lambda { |env| 
+        [
+          200,
+          {
+            'Content-Type' => 'text/plain',
+            'Last-Modified' => 'Wed, 09 Apr 2008 23:55:38 GMT',
+            'ETag' => '123456789',
+            'Cache-Control' => 'max-age=290304000, public'
+          },
+          ['Hello']
+        ]
+      })
+    end
+
+    it "should remove caching headers" do
+      get "/"
+      last_response.headers['Last-Modified'].should be_nil
+      last_response.headers['ETag'].should be_nil
+      last_response.headers['Cache-Control'].should be_nil
+    end
+  end
+
+end

--- a/spec/guard/konacha_spec.rb
+++ b/spec/guard/konacha_spec.rb
@@ -25,7 +25,7 @@ describe Guard::Konacha do
 
   describe '.run_all' do
     it "calls Runner.run" do
-      subject.runner.should_receive(:run).with(no_args())
+      subject.runner.should_receive(:run).with(no_args)
       subject.run_all
     end
   end

--- a/spec/guard/konacha_spec.rb
+++ b/spec/guard/konacha_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe Guard::Konacha do
-  subject { Guard::Konacha.new }
+  rails_env_file = File.expand_path('../../dummy/config/environment', __FILE__)
+  subject { Guard::Konacha.new [], :rails_environment_file => rails_env_file }
 
   before do
     # Silence UI.info output
@@ -10,46 +11,36 @@ describe Guard::Konacha do
 
   describe '#initialize' do
     it "instantiates Runner with given options" do
-      Guard::Konacha::Runner.should_receive(:new).with(:spec_dir => 'spec/assets')
-      Guard::Konacha.new [], { :spec_dir => 'spec/assets' }
+      Guard::Konacha::Runner.should_receive(:new).with(:rails_environment_file => nil, :spec_dir => 'spec/assets')
+      Guard::Konacha.new [], { :rails_environment_file => nil, :spec_dir => 'spec/assets' }
     end
   end
 
    describe '.start' do
-    it "calls Runner.kill_spin and Runner.launch_spin with 'Start'" do
-      subject.runner.should_receive(:kill_konacha)
-      subject.runner.should_receive(:launch_konacha).with('Start')
-      subject.runner.should_receive(:run_all)
+    it "starts Runner" do
+      subject.runner.should_receive(:start)
       subject.start
     end
   end
 
-  describe '.reload' do
-    it "calls Runner.kill_spin and Runner.launch_spin with 'Reload'" do
-      subject.runner.should_receive(:kill_konacha)
-      subject.runner.should_receive(:launch_konacha).with('Reload')
-      subject.reload
-    end
-  end
-
   describe '.run_all' do
-    it "calls Runner.run_all" do
-      subject.runner.should_receive(:run_all)
+    it "calls Runner.run" do
+      subject.runner.should_receive(:run).with(no_args())
       subject.run_all
     end
   end
 
     describe '.run_on_change (for guard 1.0.x and earlier)' do
     it 'calls Runner.run with file name' do
-      subject.runner.should_receive(:run).with('file_name.js')
-      subject.run_on_change('file_name.js')
+      subject.runner.should_receive(:run).with(['file_name.js'])
+      subject.run_on_change(['file_name.js'])
     end
   end
 
   describe '.run_on_changes' do
     it "calls Runner.run with file name" do
-      subject.runner.should_receive(:run).with('file_name.js')
-      subject.run_on_changes('file_name.js')
+      subject.runner.should_receive(:run).with(['file_name.js'])
+      subject.run_on_changes(['file_name.js'])
     end
 
     it "calls Runner.run with paths" do
@@ -58,10 +49,4 @@ describe Guard::Konacha do
     end
   end
 
-  describe '.stop' do
-    it 'calls Runner.kill_spin' do
-      subject.runner.should_receive(:kill_konacha)
-      subject.stop
-    end
-  end
 end


### PR DESCRIPTION
Rewrote most of the guard plugin to tie directly into Konacha::Server and added middleware into the stack to prevent the cacheing issues we were seeing. The new plugin is Konacha 3 compatible and tested against Rails 3.1, 3.2 and 4.0.
