### PR TITLE
Fix encoding error in Formatter for specs with russian characters

### DIFF
--- a/lib/guard/konacha/formatter.rb
+++ b/lib/guard/konacha/formatter.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module Guard
   class Konacha
     class Formatter < ::Konacha::Formatter

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# -*- encoding : utf-8 -*-
 unless ENV['CI']
   require 'simplecov'
   SimpleCov.start do


### PR DESCRIPTION
Forcing utf8 encoding in Formatter to fix "incompatible character
encodings: ASCII-8BIT and UTF-8" error for specs with russian
characters in Ruby 1.9.
