### PR TITLE
Dont run nonexistant tests

### DIFF
--- a/lib/guard/konacha/formatter.rb
+++ b/lib/guard/konacha/formatter.rb
@@ -20,6 +20,10 @@ module Guard
         failed_examples.empty?
       end
 
+      def any?
+        @examples.any?
+      end
+
       def write_summary
         io.puts ""
         io.puts [

--- a/lib/guard/konacha/formatter.rb
+++ b/lib/guard/konacha/formatter.rb
@@ -25,6 +25,9 @@ module Guard
       end
 
       def write_summary
+        #don't write a summary if no tests have been run
+        return if not any?
+
         io.puts ""
         io.puts [
           failed_examples_message,

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -43,10 +43,8 @@ module Guard
           end
         end
 
-        if formatter.any?
-          formatter.write_summary
-          notify
-        end
+        formatter.write_summary
+        notify
       rescue => e
         UI.error(e)
       end

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -36,17 +36,15 @@ module Guard
 
       def run(paths = [''])
         formatter.reset
-        ran_one = false
 
         paths.each do |path|
           file_path = konacha_path(path)
           if File.exist?(file_path)
             runner.run file_path
-            ran_one = true
           end
         end
 
-        if ran_one
+        if formatter.examples.any?
           formatter.write_summary
           notify
         end

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -38,13 +38,12 @@ module Guard
         formatter.reset
 
         paths.each do |path|
-          file_path = konacha_path(path)
-          if File.exist?(file_path)
-            runner.run file_path
+          if File.exists? real_path path
+            runner.run konacha_path(path)
           end
         end
 
-        if formatter.examples.any?
+        if formatter.any?
           formatter.write_summary
           notify
         end
@@ -78,6 +77,10 @@ module Guard
 
       def konacha_path(path)
         '/' + path.gsub(/^#{::Konacha.config[:spec_dir]}\/?/, '').gsub(/\.coffee$/, '').gsub(/\.js$/, '')
+      end
+
+      def real_path(path)
+        ::Konacha.config[:spec_dir] + konacha_path(path) + path[/\.js(\.coffee)?$/]
       end
 
       def unique_id

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -80,7 +80,7 @@ module Guard
       end
 
       def real_path(path)
-        ::Konacha.config[:spec_dir] + konacha_path(path) + path[/\.js(\.coffee)?$/]
+        ::Konacha.config[:spec_dir] + konacha_path(path) + (path[/\.js(\.coffee)?$/] || '')
       end
 
       def unique_id

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -13,7 +13,7 @@ module Guard
       def initialize(options={})
         @options = DEFAULT_OPTIONS.merge(options)
 
-        # Require project's rails environment file to load Konacha 
+        # Require project's rails environment file to load Konacha
         # configuration
         require_rails_environment
         raise "Konacha not loaded" unless defined? ::Konacha
@@ -38,7 +38,10 @@ module Guard
         formatter.reset
 
         paths.each do |path|
-          runner.run konacha_path(path)
+          file_path = konacha_path(path)
+          if File.exist?(file_path)
+            runner.run file_path
+          end
         end
 
         formatter.write_summary

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -36,16 +36,20 @@ module Guard
 
       def run(paths = [''])
         formatter.reset
+        ran_one = false
 
         paths.each do |path|
           file_path = konacha_path(path)
           if File.exist?(file_path)
             runner.run file_path
+            ran_one = true
           end
         end
 
-        formatter.write_summary
-        notify
+        if ran_one
+          formatter.write_summary
+          notify
+        end
       rescue => e
         UI.error(e)
       end

--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -38,7 +38,7 @@ module Guard
         formatter.reset
 
         paths.each do |path|
-          if File.exists? real_path path
+          if path.empty? or File.exists? real_path path
             runner.run konacha_path(path)
           end
         end

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -45,17 +45,22 @@ describe Guard::Konacha::Runner do
 
     before do
       runner.stub(:runner) { konacha_runner }
-      runner.stub(:formatter) { konacha_formatter }
       File.stub(:exists?) { true }
       konacha_formatter.stub(:any?) { true }
     end
 
     it 'should run each path through runner and format results' do
+      runner.stub(:formatter) { konacha_formatter }
       konacha_formatter.should_receive(:reset)
       konacha_runner.should_receive(:run).with('/1')
       konacha_runner.should_receive(:run).with('/foo/bar')
       konacha_formatter.should_receive(:write_summary)
       runner.run(['spec/javascripts/1.js', 'spec/javascripts/foo/bar.js'])
+    end
+
+    it 'should run when called with no arguemnts' do
+      konacha_runner.should_receive(:run)
+      runner.run
     end
   end
 

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -46,7 +46,8 @@ describe Guard::Konacha::Runner do
     before do
       runner.stub(:runner) { konacha_runner }
       runner.stub(:formatter) { konacha_formatter }
-      File.stub(:exist?) { true }
+      File.stub(:exists?) { true }
+      konacha_formatter.stub(:any?) { true }
     end
 
     it 'should run each path through runner and format results' do

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -46,6 +46,7 @@ describe Guard::Konacha::Runner do
     before do
       runner.stub(:runner) { konacha_runner }
       runner.stub(:formatter) { konacha_formatter }
+      File.stub(:exist?) { true }
     end
 
     it 'should run each path through runner and format results' do

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -59,6 +59,9 @@ describe Guard::Konacha::Runner do
     end
 
     it 'should run when called with no arguemnts' do
+      runner.stub(:formatter) { konacha_formatter }
+      konacha_formatter.should_receive(:write_summary)
+      konacha_formatter.should_receive(:reset)
       konacha_runner.should_receive(:run)
       runner.run
     end


### PR DESCRIPTION
If your guardfile has watchers that resolve to pathnames that don't exist, guard-konacha crashes instead of skipping those files.

For example, I was using the following watchers in my rails project to watch both the tests and the files being tested:   

```
watch(%r{^app/assets/javascripts/(.*)(\.js(\.coffee)?)$}) { |m| "#{m[1]}_test#{m[2]}" }
watch(%r{^test/javascripts/.+_test(\.js|\.js\.coffee)$})
```

The watcher for the tests themselves (2nd line) worked great, but the one that watched the javascript files and then found their corresponding test files (1st line) would crash if the test file didn't exists (I was working on foo.js, but there was no foo_test.js)

I fixed it by having the runner check to see if a file exists before it tries to run it.  

PS.  This is my first pull request on GitHub, so if I haven't done something correctly, please let me know and I will be happy to fix it.
