### PR TITLE
Update guard-konacha.gemspec

### DIFF
--- a/guard-konacha.gemspec
+++ b/guard-konacha.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = 'Automatically run konacha tests'
   s.license     = 'MIT'
 
-  s.add_dependency 'guard',   '~> 1.1'
+  s.add_dependency 'guard',   '>= 1.1'
   s.add_dependency 'konacha', '>= 3.0'
 
   s.add_development_dependency 'rspec', '>= 2.13'


### PR DESCRIPTION
depend on guard >= 1.1

tests were passed and works fine on guard 2.2.2.
