### PR TITLE
Bugfix invalid file existence path when used in a Rails engine

### DIFF
--- a/lib/guard/konacha/runner.rb
+++ b/lib/guard/konacha/runner.rb
@@ -78,7 +78,7 @@ module Guard
       end
 
       def real_path(path)
-        ::Konacha.config[:spec_dir] + konacha_path(path) + (path[/\.js(\.coffee)?$/] || '')
+        Rails.root.join(::Konacha.config[:spec_dir] + konacha_path(path) + (path[/\.js(\.coffee)?$/] || '')).to_s
       end
 
       def unique_id

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -45,17 +45,25 @@ describe Guard::Konacha::Runner do
 
     before do
       runner.stub(:runner) { konacha_runner }
-      File.stub(:exists?) { true }
       konacha_formatter.stub(:any?) { true }
     end
 
     it 'should run each path through runner and format results' do
+      File.stub(:exists?) { true }
       runner.stub(:formatter) { konacha_formatter }
       konacha_formatter.should_receive(:reset)
       konacha_runner.should_receive(:run).with('/1')
       konacha_runner.should_receive(:run).with('/foo/bar')
       konacha_formatter.should_receive(:write_summary)
       runner.run(['spec/javascripts/1.js', 'spec/javascripts/foo/bar.js'])
+    end
+
+    it 'should run each path with a valid extension' do
+      File.should_receive(:exists?).with(Rails.root.join('spec/javascripts/1.js').to_s).and_return(true)
+      File.should_receive(:exists?).with(Rails.root.join('spec/javascripts/foo/bar.js.coffee').to_s).and_return(true)
+      konacha_runner.should_receive(:run).with('/1')
+      konacha_runner.should_receive(:run).with('/foo/bar')
+      runner.run(['spec/javascripts/1.js', 'spec/javascripts/foo/bar.js.coffee'])
     end
 
     it 'should run when called with no arguemnts' do


### PR DESCRIPTION
I am using `guard-konacha` since few months, and I had some troubles with the test files paths.

The problem appears because I am working on a Rails engine. 
The Rails root is available in `myproject/test/dummy/`, and the tests in `myproject/spec/javascripts`.

Konacha is initialized with a `config.spec_dir = "../../spec/javascripts"`, and works fine this way.

When running `guard-konacha`, it skips the files because it checks for an invalid path (here, it checked `myproject/spec/javascripts/spec/javascripts/my_test_file_spec.js.coffee`).

I've updated the code to check file path existence starting with the `Rails.root`. AFAICT, this code should not change the current behavior for classic application architectures.

Please let me know if I have made something wrong. Thanks for your work !
