### PR TITLE
Guard 2.0 compatibility

### DIFF
--- a/guard-konacha.gemspec
+++ b/guard-konacha.gemspec
@@ -13,10 +13,11 @@ Gem::Specification.new do |s|
   s.description = 'Automatically run konacha tests'
   s.license     = 'MIT'
 
-  s.add_dependency 'guard',   '>= 1.1'
+  s.add_dependency 'guard',   '>= 2.0'
+  s.add_dependency('guard-compat', '~> 0.3')
   s.add_dependency 'konacha', '>= 3.0'
 
-  s.add_development_dependency 'rspec', '>= 2.13'
+  s.add_development_dependency 'rspec', '~> 2.13'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'poltergeist'

--- a/guard-konacha.gemspec
+++ b/guard-konacha.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.description = 'Automatically run konacha tests'
   s.license     = 'MIT'
 
-  s.add_dependency 'guard',   '>= 2.0'
-  s.add_dependency('guard-compat', '~> 0.3')
+  s.add_dependency 'guard', '~> 2.0'
+  s.add_dependency 'guard-compat', '~> 1.1'
   s.add_dependency 'konacha', '>= 3.0'
 
   s.add_development_dependency 'rspec', '~> 2.13'

--- a/lib/guard/konacha.rb
+++ b/lib/guard/konacha.rb
@@ -1,10 +1,9 @@
-require 'guard'
-require 'guard/guard'
+require 'guard/compat/plugin'
 require 'rails'
 require 'konacha'
 
 module Guard
-  class Konacha < Guard
+  class Konacha < Plugin
 
     autoload :Runner, 'guard/konacha/runner'
     autoload :Formatter, 'guard/konacha/formatter'
@@ -12,7 +11,7 @@ module Guard
 
     attr_accessor :runner
 
-    def initialize(watchers=[], options={})
+    def initialize(options = {})
       super
       @runner = Runner.new(options)
     end

--- a/spec/guard/konacha/formatter_spec.rb
+++ b/spec/guard/konacha/formatter_spec.rb
@@ -51,7 +51,7 @@ describe Guard::Konacha::Formatter do
       })
     end
 
-    let(:io) { double("IO") }
+    let(:io) { double("IO", :tty? => true) }
 
     before do
       formatter.stub(:io) { io }

--- a/spec/guard/konacha/runner_spec.rb
+++ b/spec/guard/konacha/runner_spec.rb
@@ -9,6 +9,7 @@ describe Guard::Konacha::Runner do
   before do
     # Silence Ui.info output
     ::Guard::UI.stub :info => true
+    ::Guard::Notifier.stub :notify => true
   end
 
   describe '#initialize' do

--- a/spec/guard/konacha_spec.rb
+++ b/spec/guard/konacha_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe Guard::Konacha do
   rails_env_file = File.expand_path('../../dummy/config/environment', __FILE__)
-  subject { Guard::Konacha.new [], :rails_environment_file => rails_env_file }
+  let(:options) { {:rails_environment_file => rails_env_file} }
+  subject { Guard::Konacha.new(options) }
 
   before do
     # Silence UI.info output
@@ -12,7 +13,7 @@ describe Guard::Konacha do
   describe '#initialize' do
     it "instantiates Runner with given options" do
       Guard::Konacha::Runner.should_receive(:new).with(:rails_environment_file => nil, :spec_dir => 'spec/assets')
-      Guard::Konacha.new [], { :rails_environment_file => nil, :spec_dir => 'spec/assets' }
+      Guard::Konacha.new(:rails_environment_file => nil, :spec_dir => 'spec/assets')
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ end
 
 require 'rspec'
 require 'timecop'
+require 'guard/compat/test/helper'
 require 'guard/konacha'
 
 ENV["GUARD_ENV"] = 'test'


### PR DESCRIPTION
Changes required to support Guard 2.0. This means minor changes to the `Guard::Konacha` class (the base class and the initializer arguments changed).

Added `guard-compat` gem so that specs will run. This helps with the proper setup of Guard itself, which is necessary because `Guard.state` was used in the `Plugin` base class initializer but it's nil without proper setup.
